### PR TITLE
Added optional chaining for location

### DIFF
--- a/src/pages/AddEvent/AdminEvents.js
+++ b/src/pages/AddEvent/AdminEvents.js
@@ -84,8 +84,8 @@ const AdminEvents = function ({ currentLang }) {
       title: t("Location", { lng: currentLang }),
       dataIndex: "hasLegacyCapability",
       key: "hasLegacyCapability",
-      render: (e, record) => <div>{record.locationName[currentLang]}</div>,
-    },
+      render: (e, record) => <div>{record?.locationName?.[currentLang]}</div>,
+    },  
     {
       title: t("Published", { lng: currentLang }),
       dataIndex: "hasDependency",


### PR DESCRIPTION
When @troughc was testing she deleted a location used by an event. This caused the admin tool to crash. I added optional chaining for location so a missing location does not prevent the list of events from displaying.